### PR TITLE
use offical ES open source only images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,21 @@
 version: '3'
 
 services:
-  elasticsearch:  
-    image: elasticsearch
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.3
     command: elasticsearch -Enode.name=derp -Ecluster.name=logging
     ports:
       - "9200:9200"
 
-  logstash:  
-    image: logstash
+  logstash:
+    image: docker.elastic.co/logstash/logstash-oss:6.1.3
     command: logstash -f /etc/logstash/conf.d/logstash.conf
     volumes:
     - ./logstash:/etc/logstash/conf.d
     ports:
     - "5000:5000"
 
-  kibana:  
-    image: kibana
+  kibana:
+    image: docker.elastic.co/kibana/kibana-oss:6.1.3
     ports:
       - "5601:5601"


### PR DESCRIPTION
since the "official" repos on docker hub are [depreciated](https://hub.docker.com/_/elasticsearch/), here's a PR to use the officially created Open Source only images produced by Elastic. 

